### PR TITLE
build: potentially fix windows dev installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ write_to = "eqt/_dist_ver.py"
 write_to_template = "__version__ = '{version}'\n"
 
 [tool.setuptools.packages.find]
-exclude = ["test", "examples"]
+exclude = ["test", "examples", "build*"]
 
 [project.urls]
 documentation = "https://github.com/TomographicImaging/eqt#readme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ write_to = "eqt/_dist_ver.py"
 write_to_template = "__version__ = '{version}'\n"
 
 [tool.setuptools.packages.find]
-exclude = ["test", "examples", "build*"]
+include = ["eqt", "eqt.*"]
 
 [project.urls]
 documentation = "https://github.com/TomographicImaging/eqt#readme"


### PR DESCRIPTION
In theory, I would've hoped that subsequent `pip install .` would ignore the temporary `build` directories they created.