### PR TITLE
Save entries by default in the Form Dialog

### DIFF
--- a/eqt/ui/FormDialog.py
+++ b/eqt/ui/FormDialog.py
@@ -25,9 +25,7 @@ class FormDialog(QtWidgets.QDialog):
         self.formWidget.uiElements['verticalLayout'].addWidget(bb)
         bb.button(QtWidgets.QDialogButtonBox.Ok).clicked.connect(self._onOk)
         bb.button(QtWidgets.QDialogButtonBox.Cancel).clicked.connect(self._onCancel)
-
         
-
     @property
     def Ok(self):
         '''returns a reference to the Dialog Ok button to connect its signals'''
@@ -40,22 +38,23 @@ class FormDialog(QtWidgets.QDialog):
 
     def _onOk(self):
         '''calls `onOk`'''
-        print("I am _onOk")
+        self.saveAllWidgetStates()  
         self.onOk()
 
     def _onCancel(self):
-        '''calls onCancel and closes the FormDialog'''  
+        '''calls onCancel and closes the FormDialog'''
         self.onCancel()
+        self.restoreAllSavedWidgetStates()
         self.close()
 
     def onOk(self):
         '''Called when the dialog's "Ok" button is clicked.
-          Can be redefined to add additional functionality on "Ok"'''
+        Can be redefined to add additional functionality on "Ok"'''
         pass
 
     def onCancel(self):
         '''Called when the dialog's "Cancel" button is clicked.
-          Can be redefined to add additional functionality on "Cancel"'''
+        Can be redefined to add additional functionality on "Cancel"'''
         pass
 
     @property

--- a/eqt/ui/FormDialog.py
+++ b/eqt/ui/FormDialog.py
@@ -37,12 +37,12 @@ class FormDialog(QtWidgets.QDialog):
         return self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel)
 
     def _onOk(self):
-        '''calls `onOk`'''
+        '''saves the widget states and calls `onOk`'''
         self.saveAllWidgetStates()  
         self.onOk()
 
     def _onCancel(self):
-        '''calls onCancel and closes the FormDialog'''
+        '''calls `onCancel`, restores the previously saved states if existing and closes the FormDialog'''
         self.onCancel()
         self.restoreAllSavedWidgetStates()
         self.close()

--- a/eqt/ui/FormDialog.py
+++ b/eqt/ui/FormDialog.py
@@ -25,7 +25,7 @@ class FormDialog(QtWidgets.QDialog):
         self.formWidget.uiElements['verticalLayout'].addWidget(bb)
         bb.button(QtWidgets.QDialogButtonBox.Ok).clicked.connect(self._onOk)
         bb.button(QtWidgets.QDialogButtonBox.Cancel).clicked.connect(self._onCancel)
-        
+
     @property
     def Ok(self):
         '''returns a reference to the Dialog Ok button to connect its signals'''
@@ -38,11 +38,12 @@ class FormDialog(QtWidgets.QDialog):
 
     def _onOk(self):
         '''saves the widget states and calls `onOk`'''
-        self.saveAllWidgetStates()  
+        self.saveAllWidgetStates()
         self.onOk()
 
     def _onCancel(self):
-        '''calls `onCancel`, restores the previously saved states if existing and closes the FormDialog'''
+        '''calls `onCancel`, restores the previously saved states if existing and
+          closes the FormDialog'''
         self.onCancel()
         self.restoreAllSavedWidgetStates()
         self.close()

--- a/eqt/ui/FormDialog.py
+++ b/eqt/ui/FormDialog.py
@@ -23,7 +23,10 @@ class FormDialog(QtWidgets.QDialog):
             self.setWindowTitle(title)
         # add button box to the UI
         self.formWidget.uiElements['verticalLayout'].addWidget(bb)
+        bb.button(QtWidgets.QDialogButtonBox.Ok).clicked.connect(self._onOk)
         bb.button(QtWidgets.QDialogButtonBox.Cancel).clicked.connect(self._onCancel)
+
+        
 
     @property
     def Ok(self):
@@ -35,10 +38,20 @@ class FormDialog(QtWidgets.QDialog):
         '''returns a reference to the Dialog Cancel button to connect its signals'''
         return self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel)
 
+    def _onOk(self):
+        '''calls `onOk`'''
+        print("I am _onOk")
+        self.onOk()
+
     def _onCancel(self):
-        '''calls onCancel and closes the FormDialog'''
+        '''calls onCancel and closes the FormDialog'''  
         self.onCancel()
         self.close()
+
+    def onOk(self):
+        '''Called when the dialog's "Ok" button is clicked.
+          Can be redefined to add additional functionality on "Ok"'''
+        pass
 
     def onCancel(self):
         '''Called when the dialog's "Cancel" button is clicked.

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -1,0 +1,86 @@
+import sys
+
+from PySide2 import QtWidgets
+
+from eqt.ui import FormDialog
+
+
+class MainUI(QtWidgets.QMainWindow):
+    def __init__(self, parent=None):
+        QtWidgets.QMainWindow.__init__(self, parent)
+
+        pb = QtWidgets.QPushButton(self)
+        pb.setText("Open Dialog with form layout")
+
+        pb.clicked.connect(lambda: self.executedialog())
+        
+        layout = QtWidgets.QHBoxLayout()
+        layout.addWidget(pb)
+        widg = QtWidgets.QWidget()
+        widg.setLayout(layout)
+
+        self.setCentralWidget(widg)
+        self.dialog = FormDialog(parent=self, title='Example')
+
+        self.openFormDialog()
+        self.show()
+
+    def openFormDialog(self):
+        # Example on how to add elements to the FormDialog
+        # add input 1 as QLineEdit
+        qlabel = QtWidgets.QLabel(self.dialog.groupBox)
+        qlabel.setText("Input 1: ")
+        qwidget = QtWidgets.QLineEdit(self.dialog.groupBox)
+        qwidget.setClearButtonEnabled(True)
+        # finally add to the form widget
+        self.dialog.addSpanningWidget(QtWidgets.QLabel("Input Values: "), 'input_title')
+        self.dialog.addWidget(qwidget, qlabel, 'input1')
+
+        # add input 2 as QComboBox
+        qlabel = QtWidgets.QLabel(self.dialog.groupBox)
+        qlabel.setText("Input 2: ")
+        qwidget = QtWidgets.QComboBox(self.dialog.groupBox)
+        qwidget.addItem("option 1")
+        qwidget.addItem("option 2")
+        qwidget.setCurrentIndex(0)
+        qwidget.setEnabled(True)
+        # finally add to the form widget
+        self.dialog.addWidget(qwidget, qlabel, 'input2')
+        self.dialog.addWidget(QtWidgets.QLabel("Example Vertical Layout Text"), layout="vertical")
+
+        # Example of using 'getWidget':
+        self.dialog.getWidget('input2').setCurrentIndex(1)
+
+        # store a reference
+        #self.dialog = dialog
+        self.dialog.onOk = self.accepted
+        self.dialog.onCancel = self.rejected
+
+        #self.dialog.restoreAllSavedWidgetStates()
+        if hasattr(self.dialog, 'widget_states'):
+            print("There are states")
+            print(self.dialog.widget_states)
+    
+    def executedialog(self):
+        self.dialog.restoreAllSavedWidgetStates()
+        self.dialog.exec()
+
+    def accepted(self):
+        self.dialog.widget_states = self.dialog.saveAllWidgetStates()    
+        print("accepted")
+        print(self.dialog.widgets['input1_field'].text())
+        print(self.dialog.widgets['input2_field'].currentText())
+        #print(self.widget_states)
+        print(self.dialog.widget_states)
+        self.dialog.close()
+
+    def rejected(self):
+        print("rejected")
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+
+    window = MainUI()
+
+    sys.exit(app.exec_())

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -26,13 +26,11 @@ class MainUI(QtWidgets.QMainWindow):
         self.show()
 
     def openFormDialog(self):
-        # Example on how to add elements to the FormDialog
         # add input 1 as QLineEdit
         qlabel = QtWidgets.QLabel(self.dialog.groupBox)
         qlabel.setText("Input 1: ")
         qwidget = QtWidgets.QLineEdit(self.dialog.groupBox)
         qwidget.setClearButtonEnabled(True)
-        # finally add to the form widget
         self.dialog.addSpanningWidget(QtWidgets.QLabel("Input Values: "), 'input_title')
         self.dialog.addWidget(qwidget, qlabel, 'input1')
 
@@ -44,34 +42,24 @@ class MainUI(QtWidgets.QMainWindow):
         qwidget.addItem("option 2")
         qwidget.setCurrentIndex(0)
         qwidget.setEnabled(True)
-        # finally add to the form widget
         self.dialog.addWidget(qwidget, qlabel, 'input2')
         self.dialog.addWidget(QtWidgets.QLabel("Example Vertical Layout Text"), layout="vertical")
 
         # Example of using 'getWidget':
         self.dialog.getWidget('input2').setCurrentIndex(1)
 
-        # store a reference
-        #self.dialog = dialog
+        #redefine the onOk and onCancel functions
         self.dialog.onOk = self.accepted
         self.dialog.onCancel = self.rejected
 
-        #self.dialog.restoreAllSavedWidgetStates()
-        if hasattr(self.dialog, 'widget_states'):
-            print("There are states")
-            print(self.dialog.widget_states)
-    
+    #open dialog function when the parent button is clicked
     def executedialog(self):
-        self.dialog.restoreAllSavedWidgetStates()
-        self.dialog.exec()
+        self.dialog.open()
 
     def accepted(self):
-        self.dialog.widget_states = self.dialog.saveAllWidgetStates()    
         print("accepted")
         print(self.dialog.widgets['input1_field'].text())
         print(self.dialog.widgets['input2_field'].currentText())
-        #print(self.widget_states)
-        print(self.dialog.widget_states)
         self.dialog.close()
 
     def rejected(self):

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -5,16 +5,14 @@ from PySide2 import QtWidgets
 from eqt.ui import FormDialog
 from eqt.ui.UISliderWidget import UISliderWidget
 
-
 class MainUI(QtWidgets.QMainWindow):
     def __init__(self, parent=None):
         QtWidgets.QMainWindow.__init__(self, parent)
 
         pb = QtWidgets.QPushButton(self)
         pb.setText("Open Dialog with form layout")
-
         pb.clicked.connect(lambda: self.executedialog())
-        
+    
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(pb)
         widg = QtWidgets.QWidget()
@@ -22,133 +20,43 @@ class MainUI(QtWidgets.QMainWindow):
 
         self.setCentralWidget(widg)
         self.dialog = FormDialog(parent=self, title='Example')
-
         self.openFormDialog()
 
-        
-
-
-
-        self.setstate(0)
-        self.setstate(1)
         self.show()
 
     def openFormDialog(self):
-        # add input 1 as QLineEdit
-        qlabel = QtWidgets.QLabel(self.dialog.groupBox)
-        qlabel.setText("Input 1: ")
-        qwidget = QtWidgets.QLineEdit(self.dialog.groupBox)
-        qwidget.setClearButtonEnabled(True)
+        # add a spanning widget
         self.dialog.addSpanningWidget(QtWidgets.QLabel("Input Values: "), 'input_title')
-        self.dialog.addWidget(qwidget, qlabel, 'input1')
-
-        # add input 2 as QComboBox
-        qlabel = QtWidgets.QLabel(self.dialog.groupBox)
-        qlabel.setText("Input 2: ")
-        qwidget = QtWidgets.QComboBox(self.dialog.groupBox)
-        qwidget.addItem("option 1")
-        qwidget.addItem("option 2")
-        qwidget.setCurrentIndex(0)
-        qwidget.setEnabled(True)
-        self.dialog.addWidget(qwidget, qlabel, 'input2')
-        self.dialog.addWidget(QtWidgets.QLabel("Example Vertical Layout Text"), layout="vertical")
-
-        # Example of using 'getWidget':
-        self.dialog.getWidget('input2').setCurrentIndex(1)
-        form=self.dialog
-        form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
-        form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
-        form.addWidget(QtWidgets.QComboBox(), 'ComboBox: ', 'comboBox')
-        form.addWidget(QtWidgets.QDoubleSpinBox(), 'DoubleSpinBox: ', 'doubleSpinBox')
-        form.addWidget(QtWidgets.QSpinBox(), 'SpinBox: ', 'spinBox')
-        form.addWidget(QtWidgets.QSlider(), 'Slider: ', 'slider')
-        form.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISliderWidget: ', 'uiSliderWidget')
-        form.addWidget(QtWidgets.QRadioButton('test'), 'RadioButton: ', 'radioButton')
-        form.addWidget(QtWidgets.QTextEdit('test'), 'TextEdit: ', 'textEdit')
-        form.addWidget(QtWidgets.QPlainTextEdit('test'), 'PlainTextEdit: ', 'plainTextEdit')
-        form.addWidget(QtWidgets.QLineEdit('test'), 'LineEdit: ', 'lineEdit')
-        form.addWidget(QtWidgets.QPushButton('test'), 'Button: ', 'button')
-
-        
-
-        
+        # add all widgets
+        self.dialog.addWidget(QtWidgets.QLabel('Label'), 'Label: ', 'label')
+        self.dialog.addWidget(QtWidgets.QCheckBox('check me'), 'CheckBox: ', 'checkBox')
+        combobox_list = ['choice 1', 'choice 2']
+        self.dialog.addWidget(QtWidgets.QComboBox(), 'ComboBox: ', 'comboBox')
+        self.dialog.getWidget('comboBox').addItems(combobox_list)
+        self.dialog.addWidget(QtWidgets.QDoubleSpinBox(), 'DoubleSpinBox: ', 'doubleSpinBox')
+        self.dialog.addWidget(QtWidgets.QSpinBox(), 'SpinBox: ', 'spinBox')
+        self.dialog.addWidget(QtWidgets.QSlider(), 'Slider: ', 'slider')
+        self.dialog.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISlider: ', 'uiSliderWidget')
+        self.dialog.addWidget(QtWidgets.QRadioButton('select me'), 'RadioButton: ', 'radioButton')
+        self.dialog.addWidget(QtWidgets.QTextEdit('write text here'), 'TextEdit: ', 'textEdit')
+        self.dialog.addWidget(QtWidgets.QPlainTextEdit('write text here'), 'PlainTextEdit: ', 'plainTextEdit')
+        self.dialog.addWidget(QtWidgets.QLineEdit('write text here'), 'LineEdit: ', 'lineEdit')
+        self.dialog.addWidget(QtWidgets.QPushButton('Click me'), 'Button: ', 'button')
 
         #redefine the onOk and onCancel functions
         self.dialog.onOk = self.accepted
         self.dialog.onCancel = self.rejected
 
-    def setstate(self,ii):
+    def accepted(self):
+        print("States saved")
+        self.dialog.close()
 
-        state=[0,0]
-        state[1] = {'label_value': 'Test label state 1',
-                    'checkbox_value':True,
-                    'combobox_value': 1,
-                    'doubleSpinBox_value': 1.0,
-                    'spinBox_value': 1,
-                    'slider_value': 1,
-                    'uislider_value': 1,
-                    'radio_value': True,
-                    'textEdit_value': 'test edit 1',
-                    'plainTextEdit_value': 'test plain 1',
-                    'lineEdit_value': 'test line 1',
-                    'button_value': True               
-                    }
-        
-        state[0] = {'label_value': 'Test label state 0',
-                    'checkbox_value':False,
-                    'combobox_value': 0,
-                    'doubleSpinBox_value': 10.0,
-                    'spinBox_value': 10,
-                    'slider_value': 10,
-                    'uislider_value': 10,
-                    'radio_value': False,
-                    'textEdit_value': 'test edit 0',
-                    'plainTextEdit_value': 'test plain 0',
-                    'lineEdit_value': 'test line 0',
-                    'button_value': False               
-                    }
-
-        self.dialog.getWidget('label').setText(state[ii]['label_value'])
-        self.dialog.getWidget('checkBox').setChecked(state[ii]['checkbox_value'])
-        
-        combobox_list = ['test', 'test2']
-        self.dialog.getWidget('comboBox').addItems(combobox_list)
-        self.dialog.getWidget('comboBox').setCurrentIndex(state[ii]['combobox_value'])
-        
-        self.dialog.getWidget('doubleSpinBox').setValue(state[ii]['doubleSpinBox_value'])
-
-        self.dialog.getWidget('spinBox').setValue(state[ii]['spinBox_value'])
-
-        self.dialog.getWidget('slider').setValue(state[ii]['slider_value'])
-
-        self.dialog.getWidget('uiSliderWidget').setValue(state[ii]['uislider_value'])
-
-        self.dialog.getWidget('textEdit').setText(state[ii]['textEdit_value'])
-
-        self.dialog.getWidget('plainTextEdit').setPlainText(state[ii]['plainTextEdit_value'])
-
-        self.dialog.getWidget('lineEdit').setText(state[ii]['lineEdit_value'])
-
-        self.dialog.getWidget('button').setCheckable(True)
-        self.dialog.getWidget('button').setChecked(state[ii]['button_value'])
-
-        self.dialog.getWidget('radioButton').setChecked(state[ii]['radio_value'])
-
-
+    def rejected(self):
+        print("States rejected")
 
     #open dialog function when the parent button is clicked
     def executedialog(self):
         self.dialog.open()
-
-    def accepted(self):
-        print("accepted")
-        print(self.dialog.widgets['input1_field'].text())
-        print(self.dialog.widgets['input2_field'].currentText())
-        self.dialog.close()
-
-    def rejected(self):
-        print("rejected")
-
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -5,6 +5,7 @@ from PySide2 import QtWidgets
 from eqt.ui import FormDialog
 from eqt.ui.UISliderWidget import UISliderWidget
 
+
 class MainUI(QtWidgets.QMainWindow):
     def __init__(self, parent=None):
         QtWidgets.QMainWindow.__init__(self, parent)
@@ -12,7 +13,7 @@ class MainUI(QtWidgets.QMainWindow):
         pb = QtWidgets.QPushButton(self)
         pb.setText("Open Dialog with form layout")
         pb.clicked.connect(lambda: self.executedialog())
-    
+
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(pb)
         widg = QtWidgets.QWidget()
@@ -39,11 +40,12 @@ class MainUI(QtWidgets.QMainWindow):
         self.dialog.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISlider: ', 'uiSliderWidget')
         self.dialog.addWidget(QtWidgets.QRadioButton('select me'), 'RadioButton: ', 'radioButton')
         self.dialog.addWidget(QtWidgets.QTextEdit('write text here'), 'TextEdit: ', 'textEdit')
-        self.dialog.addWidget(QtWidgets.QPlainTextEdit('write text here'), 'PlainTextEdit: ', 'plainTextEdit')
+        self.dialog.addWidget(QtWidgets.QPlainTextEdit('write text here'), 'PlainTextEdit: ',
+                              'plainTextEdit')
         self.dialog.addWidget(QtWidgets.QLineEdit('write text here'), 'LineEdit: ', 'lineEdit')
         self.dialog.addWidget(QtWidgets.QPushButton('Click me'), 'Button: ', 'button')
 
-        #redefine the onOk and onCancel functions
+        # redefine the onOk and onCancel functions
         self.dialog.onOk = self.accepted
         self.dialog.onCancel = self.rejected
 
@@ -54,9 +56,10 @@ class MainUI(QtWidgets.QMainWindow):
     def rejected(self):
         print("States rejected")
 
-    #open dialog function when the parent button is clicked
+    # open dialog function when the parent button is clicked
     def executedialog(self):
         self.dialog.open()
+
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -3,6 +3,7 @@ import sys
 from PySide2 import QtWidgets
 
 from eqt.ui import FormDialog
+from eqt.ui.UISliderWidget import UISliderWidget
 
 
 class MainUI(QtWidgets.QMainWindow):
@@ -23,6 +24,13 @@ class MainUI(QtWidgets.QMainWindow):
         self.dialog = FormDialog(parent=self, title='Example')
 
         self.openFormDialog()
+
+        
+
+
+
+        self.setstate(0)
+        self.setstate(1)
         self.show()
 
     def openFormDialog(self):
@@ -47,10 +55,86 @@ class MainUI(QtWidgets.QMainWindow):
 
         # Example of using 'getWidget':
         self.dialog.getWidget('input2').setCurrentIndex(1)
+        form=self.dialog
+        form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
+        form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
+        form.addWidget(QtWidgets.QComboBox(), 'ComboBox: ', 'comboBox')
+        form.addWidget(QtWidgets.QDoubleSpinBox(), 'DoubleSpinBox: ', 'doubleSpinBox')
+        form.addWidget(QtWidgets.QSpinBox(), 'SpinBox: ', 'spinBox')
+        form.addWidget(QtWidgets.QSlider(), 'Slider: ', 'slider')
+        form.addWidget(UISliderWidget(QtWidgets.QLabel()), 'UISliderWidget: ', 'uiSliderWidget')
+        form.addWidget(QtWidgets.QRadioButton('test'), 'RadioButton: ', 'radioButton')
+        form.addWidget(QtWidgets.QTextEdit('test'), 'TextEdit: ', 'textEdit')
+        form.addWidget(QtWidgets.QPlainTextEdit('test'), 'PlainTextEdit: ', 'plainTextEdit')
+        form.addWidget(QtWidgets.QLineEdit('test'), 'LineEdit: ', 'lineEdit')
+        form.addWidget(QtWidgets.QPushButton('test'), 'Button: ', 'button')
+
+        
+
+        
 
         #redefine the onOk and onCancel functions
         self.dialog.onOk = self.accepted
         self.dialog.onCancel = self.rejected
+
+    def setstate(self,ii):
+
+        state=[0,0]
+        state[1] = {'label_value': 'Test label state 1',
+                    'checkbox_value':True,
+                    'combobox_value': 1,
+                    'doubleSpinBox_value': 1.0,
+                    'spinBox_value': 1,
+                    'slider_value': 1,
+                    'uislider_value': 1,
+                    'radio_value': True,
+                    'textEdit_value': 'test edit 1',
+                    'plainTextEdit_value': 'test plain 1',
+                    'lineEdit_value': 'test line 1',
+                    'button_value': True               
+                    }
+        
+        state[0] = {'label_value': 'Test label state 0',
+                    'checkbox_value':False,
+                    'combobox_value': 0,
+                    'doubleSpinBox_value': 10.0,
+                    'spinBox_value': 10,
+                    'slider_value': 10,
+                    'uislider_value': 10,
+                    'radio_value': False,
+                    'textEdit_value': 'test edit 0',
+                    'plainTextEdit_value': 'test plain 0',
+                    'lineEdit_value': 'test line 0',
+                    'button_value': False               
+                    }
+
+        self.dialog.getWidget('label').setText(state[ii]['label_value'])
+        self.dialog.getWidget('checkBox').setChecked(state[ii]['checkbox_value'])
+        
+        combobox_list = ['test', 'test2']
+        self.dialog.getWidget('comboBox').addItems(combobox_list)
+        self.dialog.getWidget('comboBox').setCurrentIndex(state[ii]['combobox_value'])
+        
+        self.dialog.getWidget('doubleSpinBox').setValue(state[ii]['doubleSpinBox_value'])
+
+        self.dialog.getWidget('spinBox').setValue(state[ii]['spinBox_value'])
+
+        self.dialog.getWidget('slider').setValue(state[ii]['slider_value'])
+
+        self.dialog.getWidget('uiSliderWidget').setValue(state[ii]['uislider_value'])
+
+        self.dialog.getWidget('textEdit').setText(state[ii]['textEdit_value'])
+
+        self.dialog.getWidget('plainTextEdit').setPlainText(state[ii]['plainTextEdit_value'])
+
+        self.dialog.getWidget('lineEdit').setText(state[ii]['lineEdit_value'])
+
+        self.dialog.getWidget('button').setCheckable(True)
+        self.dialog.getWidget('button').setChecked(state[ii]['button_value'])
+
+        self.dialog.getWidget('radioButton').setChecked(state[ii]['radio_value'])
+
+
 
     #open dialog function when the parent button is clicked
     def executedialog(self):

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -3,6 +3,8 @@ import unittest
 from unittest import mock
 
 from PySide2 import QtWidgets
+from PySide2.QtTest import QTest
+from PySide2.QtCore import Qt
 
 from eqt.ui.FormDialog import FormDialog
 from eqt.ui.UIFormWidget import FormDockWidget, FormWidget
@@ -38,6 +40,64 @@ class FormsCommonTests(metaclass=abc.ABCMeta):
         form = self.simple_form
         form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
         form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
+
+    def set_state(self,ii):
+        #define two states for every widget
+        state=[0,0]
+        state[1] = {'label_value': 'Test label state 1',
+                    'checkbox_value':True,
+                    'combobox_value': 1,
+                    'doubleSpinBox_value': 1.0,
+                    'spinBox_value': 1,
+                    'slider_value': 1,
+                    'uislider_value': 1,
+                    'radio_value': True,
+                    'textEdit_value': 'test edit 1',
+                    'plainTextEdit_value': 'test plain 1',
+                    'lineEdit_value': 'test line 1',
+                    'pushButton_value': True               
+                    }
+        state[0] = {'label_value': 'Test label state 0',
+                    'checkbox_value':False,
+                    'combobox_value': 0,
+                    'doubleSpinBox_value': 10.0,
+                    'spinBox_value': 10,
+                    'slider_value': 10,
+                    'uislider_value': 10,
+                    'radio_value': False,
+                    'textEdit_value': 'test edit 0',
+                    'plainTextEdit_value': 'test plain 0',
+                    'lineEdit_value': 'test line 0',
+                    'pushButton_value': False               
+                    }
+        #set the states
+        #QLabel
+        self.form.getWidget('label').setText(state[ii]['label_value'])
+        #QCheckBox
+        self.form.getWidget('checkBox').setChecked(state[ii]['checkbox_value'])
+        #QComboBox
+        combobox_list = ['test', 'test2']
+        self.form.getWidget('comboBox').addItems(combobox_list)
+        self.form.getWidget('comboBox').setCurrentIndex(state[ii]['combobox_value'])
+        #QDoubleSpinBox
+        self.form.getWidget('doubleSpinBox').setValue(state[ii]['doubleSpinBox_value'])
+        #QSpinBox
+        self.form.getWidget('spinBox').setValue(state[ii]['spinBox_value'])
+        #QSlider
+        self.form.getWidget('slider').setValue(state[ii]['slider_value'])
+        #UISlider
+        self.form.getWidget('uiSliderWidget').setValue(state[ii]['uislider_value'])
+        #QRadioButton
+        self.form.getWidget('radioButton').setChecked(state[ii]['radio_value'])
+        #QTextEdit
+        self.form.getWidget('textEdit').setText(state[ii]['textEdit_value'])
+        #QPlainTextEdit
+        self.form.getWidget('plainTextEdit').setPlainText(state[ii]['plainTextEdit_value'])
+        #QLineEdit
+        self.form.getWidget('lineEdit').setText(state[ii]['lineEdit_value'])
+        #QPushButton
+        self.form.getWidget('button').setCheckable(True)
+        self.form.getWidget('button').setChecked(state[ii]['pushButton_value'])
 
     def test_getWidgetState_returns_visibility(self):
         """
@@ -295,6 +355,48 @@ class FormDialogStatusTest(FormsCommonTests, unittest.TestCase):
         self.add_every_widget()
         self.simple_form = FormDialog()
         self.add_two_widgets()
+
+    def click_Ok(self):
+        QTest.mouseClick(self.form.Ok, Qt.LeftButton)
+
+    def click_Cancel(self):
+        QTest.mouseClick(self.form.Cancel, Qt.LeftButton)
+
+    def test_save_states_default(self):
+        #test both states are working
+        self.set_state(1)
+        states1=self.form.getAllWidgetStates()
+        self.set_state(0)
+        states0=self.form.getAllWidgetStates()
+        self.assertEqual(states0,states0)
+        self.assertEqual(states1,states1)
+        #self.assertEqual(states0,states1)
+        # Click the Ok button
+        self.click_Ok()
+        #self.form.close()
+
+        #self.form.open()
+        self.assertEqual(states0,self.form.getAllWidgetStates())
+        #self.assertEqual(states0,states1)
+        #self.assertEqual(states0,states0)
+
+        # Click the Ok button
+        self.click_Ok()
+        self.form.close()
+
+        self.form.open()
+        # #check states are states 1
+        self.set_state(0)
+        self.click_Cancel()
+        self.form.close()
+
+        self.form.open()
+        # #check states are states 1
+        self.set_state(0)
+        # #press ok
+        self.form.close()
+        self.form.open()
+        # check states are states 0
 
     def test_getWidgetState_returns_QLabel_value(self):
         """Check that the value of the QLabel is saved to the state"""

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -44,19 +44,6 @@ class FormsCommonTests(metaclass=abc.ABCMeta):
     def set_state(self,ii):
         #define two states for every widget
         state=[0,0]
-        state[1] = {'label_value': 'Test label state 1',
-                    'checkbox_value':True,
-                    'combobox_value': 1,
-                    'doubleSpinBox_value': 1.0,
-                    'spinBox_value': 1,
-                    'slider_value': 1,
-                    'uislider_value': 1,
-                    'radio_value': True,
-                    'textEdit_value': 'test edit 1',
-                    'plainTextEdit_value': 'test plain 1',
-                    'lineEdit_value': 'test line 1',
-                    'pushButton_value': True               
-                    }
         state[0] = {'label_value': 'Test label state 0',
                     'checkbox_value':False,
                     'combobox_value': 0,
@@ -69,6 +56,19 @@ class FormsCommonTests(metaclass=abc.ABCMeta):
                     'plainTextEdit_value': 'test plain 0',
                     'lineEdit_value': 'test line 0',
                     'pushButton_value': False               
+                    }
+        state[1] = {'label_value': 'Test label state 1',
+                    'checkbox_value':True,
+                    'combobox_value': 1,
+                    'doubleSpinBox_value': 1.0,
+                    'spinBox_value': 1,
+                    'slider_value': 1,
+                    'uislider_value': 1,
+                    'radio_value': True,
+                    'textEdit_value': 'test edit 1',
+                    'plainTextEdit_value': 'test plain 1',
+                    'lineEdit_value': 'test line 1',
+                    'pushButton_value': True               
                     }
         #set the states
         #QLabel

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -3,8 +3,8 @@ import unittest
 from unittest import mock
 
 from PySide2 import QtWidgets
-from PySide2.QtTest import QTest
 from PySide2.QtCore import Qt
+from PySide2.QtTest import QTest
 
 from eqt.ui.FormDialog import FormDialog
 from eqt.ui.UIFormWidget import FormDockWidget, FormWidget
@@ -41,61 +41,47 @@ class FormsCommonTests(metaclass=abc.ABCMeta):
         form.addWidget(QtWidgets.QLabel('test label'), 'Label: ', 'label')
         form.addWidget(QtWidgets.QCheckBox('test checkbox'), 'CheckBox: ', 'checkBox')
 
-    def set_state(self,ii):
-        #define two states for every widget
-        state=[0,0]
-        state[0] = {'label_value': 'Test label state 0',
-                    'checkbox_value':False,
-                    'combobox_value': 0,
-                    'doubleSpinBox_value': 10.0,
-                    'spinBox_value': 10,
-                    'slider_value': 10,
-                    'uislider_value': 10,
-                    'radio_value': False,
-                    'textEdit_value': 'test edit 0',
-                    'plainTextEdit_value': 'test plain 0',
-                    'lineEdit_value': 'test line 0',
-                    'pushButton_value': False               
-                    }
-        state[1] = {'label_value': 'Test label state 1',
-                    'checkbox_value':True,
-                    'combobox_value': 1,
-                    'doubleSpinBox_value': 1.0,
-                    'spinBox_value': 1,
-                    'slider_value': 1,
-                    'uislider_value': 1,
-                    'radio_value': True,
-                    'textEdit_value': 'test edit 1',
-                    'plainTextEdit_value': 'test plain 1',
-                    'lineEdit_value': 'test line 1',
-                    'pushButton_value': True               
-                    }
-        #set the states
-        #QLabel
+    def set_state(self, ii):
+        # define two states for every widget
+        state = [0, 0]
+        state[0] = {
+            'label_value': 'Test label state 0', 'checkbox_value': False, 'combobox_value': 0,
+            'doubleSpinBox_value': 10.0, 'spinBox_value': 10, 'slider_value': 10,
+            'uislider_value': 10, 'radio_value': False, 'textEdit_value': 'test edit 0',
+            'plainTextEdit_value': 'test plain 0', 'lineEdit_value': 'test line 0',
+            'pushButton_value': False}
+        state[1] = {
+            'label_value': 'Test label state 1', 'checkbox_value': True, 'combobox_value': 1,
+            'doubleSpinBox_value': 1.0, 'spinBox_value': 1, 'slider_value': 1, 'uislider_value': 1,
+            'radio_value': True, 'textEdit_value': 'test edit 1',
+            'plainTextEdit_value': 'test plain 1', 'lineEdit_value': 'test line 1',
+            'pushButton_value': True}
+        # set the states
+        # QLabel
         self.form.getWidget('label').setText(state[ii]['label_value'])
-        #QCheckBox
+        # QCheckBox
         self.form.getWidget('checkBox').setChecked(state[ii]['checkbox_value'])
-        #QComboBox
+        # QComboBox
         combobox_list = ['test', 'test2']
         self.form.getWidget('comboBox').addItems(combobox_list)
         self.form.getWidget('comboBox').setCurrentIndex(state[ii]['combobox_value'])
-        #QDoubleSpinBox
+        # QDoubleSpinBox
         self.form.getWidget('doubleSpinBox').setValue(state[ii]['doubleSpinBox_value'])
-        #QSpinBox
+        # QSpinBox
         self.form.getWidget('spinBox').setValue(state[ii]['spinBox_value'])
-        #QSlider
+        # QSlider
         self.form.getWidget('slider').setValue(state[ii]['slider_value'])
-        #UISlider
+        # UISlider
         self.form.getWidget('uiSliderWidget').setValue(state[ii]['uislider_value'])
-        #QRadioButton
+        # QRadioButton
         self.form.getWidget('radioButton').setChecked(state[ii]['radio_value'])
-        #QTextEdit
+        # QTextEdit
         self.form.getWidget('textEdit').setText(state[ii]['textEdit_value'])
-        #QPlainTextEdit
+        # QPlainTextEdit
         self.form.getWidget('plainTextEdit').setPlainText(state[ii]['plainTextEdit_value'])
-        #QLineEdit
+        # QLineEdit
         self.form.getWidget('lineEdit').setText(state[ii]['lineEdit_value'])
-        #QPushButton
+        # QPushButton
         self.form.getWidget('button').setCheckable(True)
         self.form.getWidget('button').setChecked(state[ii]['pushButton_value'])
 
@@ -363,47 +349,47 @@ class FormDialogStatusTest(FormsCommonTests, unittest.TestCase):
         QTest.mouseClick(self.form.Cancel, Qt.LeftButton)
 
     def test_save_states_default(self):
-        #test both states are working
+        # test both states are working
         self.form.open()
-        #state1
+        # state1
         self.set_state(1)
-        states1=self.form.getAllWidgetStates()
-        self.assertEqual(states1,self.form.getAllWidgetStates())
-        #state0
+        states1 = self.form.getAllWidgetStates()
+        self.assertEqual(states1, self.form.getAllWidgetStates())
+        # state0
         self.set_state(0)
-        states0=self.form.getAllWidgetStates()
-        self.assertNotEqual(states1,self.form.getAllWidgetStates())
-        self.assertEqual(states0,self.form.getAllWidgetStates())
-        #together
-        self.assertEqual(states0,states0)
-        self.assertEqual(states1,states1)
-        self.assertNotEqual(states0,states1)
-        #check nothing is saved when Cancel is pressed
+        states0 = self.form.getAllWidgetStates()
+        self.assertNotEqual(states1, self.form.getAllWidgetStates())
+        self.assertEqual(states0, self.form.getAllWidgetStates())
+        # together
+        self.assertEqual(states0, states0)
+        self.assertEqual(states1, states1)
+        self.assertNotEqual(states0, states1)
+        # check nothing is saved when Cancel is pressed
         self.click_Cancel()
-        self.assertNotEqual(states0,self.form.getAllWidgetStates())
-        self.assertNotEqual(states1,self.form.getAllWidgetStates())
-        #save state 0
+        self.assertNotEqual(states0, self.form.getAllWidgetStates())
+        self.assertNotEqual(states1, self.form.getAllWidgetStates())
+        # save state 0
         self.form.open()
         self.set_state(0)
-        self.assertEqual(states0,self.form.getAllWidgetStates())
-        self.click_Ok()   
+        self.assertEqual(states0, self.form.getAllWidgetStates())
+        self.click_Ok()
         self.form.close()
         self.form.open()
-        self.assertEqual(states0,self.form.getAllWidgetStates())
-        #save state 1
+        self.assertEqual(states0, self.form.getAllWidgetStates())
+        # save state 1
         self.form.open()
         self.set_state(1)
-        self.assertEqual(states1,self.form.getAllWidgetStates())
-        self.click_Ok()   
+        self.assertEqual(states1, self.form.getAllWidgetStates())
+        self.click_Ok()
         self.form.close()
         self.form.open()
-        self.assertEqual(states1,self.form.getAllWidgetStates())
-        #change to state 0 without saving
+        self.assertEqual(states1, self.form.getAllWidgetStates())
+        # change to state 0 without saving
         self.set_state(0)
-        self.assertEqual(states0,self.form.getAllWidgetStates())
-        self.click_Cancel() 
+        self.assertEqual(states0, self.form.getAllWidgetStates())
+        self.click_Cancel()
         self.form.open()
-        self.assertEqual(states1,self.form.getAllWidgetStates())
+        self.assertEqual(states1, self.form.getAllWidgetStates())
 
     def test_getWidgetState_returns_QLabel_value(self):
         """Check that the value of the QLabel is saved to the state"""

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -364,39 +364,46 @@ class FormDialogStatusTest(FormsCommonTests, unittest.TestCase):
 
     def test_save_states_default(self):
         #test both states are working
+        self.form.open()
+        #state1
         self.set_state(1)
         states1=self.form.getAllWidgetStates()
+        self.assertEqual(states1,self.form.getAllWidgetStates())
+        #state0
         self.set_state(0)
         states0=self.form.getAllWidgetStates()
+        self.assertNotEqual(states1,self.form.getAllWidgetStates())
+        self.assertEqual(states0,self.form.getAllWidgetStates())
+        #together
         self.assertEqual(states0,states0)
         self.assertEqual(states1,states1)
-        #self.assertEqual(states0,states1)
-        # Click the Ok button
-        self.click_Ok()
-        #self.form.close()
-
-        #self.form.open()
-        self.assertEqual(states0,self.form.getAllWidgetStates())
-        #self.assertEqual(states0,states1)
-        #self.assertEqual(states0,states0)
-
-        # Click the Ok button
-        self.click_Ok()
-        self.form.close()
-
-        self.form.open()
-        # #check states are states 1
-        self.set_state(0)
+        self.assertNotEqual(states0,states1)
+        #check nothing is saved when Cancel is pressed
         self.click_Cancel()
-        self.form.close()
-
+        self.assertNotEqual(states0,self.form.getAllWidgetStates())
+        self.assertNotEqual(states1,self.form.getAllWidgetStates())
+        #save state 0
         self.form.open()
-        # #check states are states 1
         self.set_state(0)
-        # #press ok
+        self.assertEqual(states0,self.form.getAllWidgetStates())
+        self.click_Ok()   
         self.form.close()
         self.form.open()
-        # check states are states 0
+        self.assertEqual(states0,self.form.getAllWidgetStates())
+        #save state 1
+        self.form.open()
+        self.set_state(1)
+        self.assertEqual(states1,self.form.getAllWidgetStates())
+        self.click_Ok()   
+        self.form.close()
+        self.form.open()
+        self.assertEqual(states1,self.form.getAllWidgetStates())
+        #change to state 0 without saving
+        self.set_state(0)
+        self.assertEqual(states0,self.form.getAllWidgetStates())
+        self.click_Cancel() 
+        self.form.open()
+        self.assertEqual(states1,self.form.getAllWidgetStates())
 
     def test_getWidgetState_returns_QLabel_value(self):
         """Check that the value of the QLabel is saved to the state"""


### PR DESCRIPTION
Closes #87 

- Form dialog saves states by default when `Ok` is clicked and restores the previously saved states (if any) when `Cancel` is clicked.
- Add example file "dialog_example_3_save_default" to demonstrate the new features.
- Add `set_state` and `test_save_states_default` to the unit tests.