### PR TITLE
Fix failing unit tests

### DIFF
--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -69,8 +69,13 @@ class SessionDirectorySelectionDialog(FormDialog):
 
         self.app_name = app_name
 
+        if app_name is not None:
+            app_name_label = ' ' + app_name
+        else:
+            app_name_label = ''
+
         label_text = ("Select a session directory to save and retrieve all"
-                      f"{app_name or ''} Sessions:")
+                      f"{app_name_label} Sessions:")
 
         self.addSpanningWidget(QLabel(label_text), 'select_session_directory')
 

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -70,7 +70,7 @@ class SessionDirectorySelectionDialog(FormDialog):
         self.app_name = app_name
 
         label_text = ("Select a session directory to save and retrieve all"
-                      f" {app_name or ''} Sessions:")
+                      f"{app_name or ''} Sessions:")
 
         self.addSpanningWidget(QLabel(label_text), 'select_session_directory')
 

--- a/test/dialog_example_2_test.py
+++ b/test/dialog_example_2_test.py
@@ -56,7 +56,7 @@ class MainUI(QtWidgets.QMainWindow):
         # store a reference
         self.dialog = dialog
 
-        dialog.exec()
+        dialog.open()
 
     def accepted(self):
         print("accepted")

--- a/test/test_MainWindowWithSessionManagement.py
+++ b/test/test_MainWindowWithSessionManagement.py
@@ -229,56 +229,12 @@ class TestMainWindowWithSessionManagementCreateSessionSelector(unittest.TestCase
 
 
 @skip_ci
-class TestMainWindowWithSessionManagementCreateLoadSessionDialog(unittest.TestCase):
-    '''
-    Tests the createLoadSessionDialog method of the MainWindowWithSessionManagement class
-
-    This method is responsible for creating the load session dialog
-    and populating it with the available sessions
-    '''
-    def setUp(self):
-        self.title = "title"
-        self.app_name = "app_name"
-        self.smw = MainWindowWithSessionManagement(self.title, self.app_name)
-        self.smw.sessions_directory = mock.MagicMock()
-        self.zip_folders = ["zip_folder_1", "zip_folder_2"]
-
-    def test_createLoadSessionDialog_populates_session_dropdown(self):
-        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
-        assert dialog is not None
-        assert isinstance(dialog, eqt.ui.SessionDialogs.LoadSessionDialog)
-        select_session_combo = dialog.getWidget('select_session')
-        assert select_session_combo is not None
-        items_in_combo = [
-            select_session_combo.itemText(i) for i in range(select_session_combo.count())]
-        assert items_in_combo == self.zip_folders
-
-    def test_createLoadSessionDialog_connections(self):
-        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
-
-        self.smw.loadSessionLoad = mock.MagicMock()
-        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector = mock.MagicMock()
-        self.smw.loadSessionNew = mock.MagicMock()
-
-        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
-
-        dialog.Ok.click()
-        self.smw.loadSessionLoad.assert_called_once()
-
-        dialog.Select.click()
-        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector.assert_called_with(dialog)
-
-        dialog.Cancel.click()
-        self.smw.loadSessionNew.assert_called_once()
-
-
-@skip_ci
 class TestSelectLoadSessionsDirectorySelectedInSessionSelector(unittest.TestCase):
     '''
     Tests the `selectLoadSessionsDirectorySelectedInSessionSelector` method of the
     `MainWindowWithSessionManagement` class
 
-    This method sould close the passed dialog, and call
+    This method should close the passed dialog, and call
     `createSessionsDirectorySelectionDialog(new_session=True)`
     '''
     def setUp(self):

--- a/test/test_MainWindowWithSessionManagementDialogs.py
+++ b/test/test_MainWindowWithSessionManagementDialogs.py
@@ -1,20 +1,11 @@
 
-import json
-import os
-import shutil
 import unittest
-from datetime import datetime
 from unittest import mock
-from unittest.mock import patch
 
-from PySide2.QtCore import QSettings, QThreadPool
-from PySide2.QtWidgets import QMenu, QMenuBar
-
-import eqt
 from eqt.io import zip_directory
 from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 
-from eqt.ui.SessionDialogs import (LoadSessionDialog)
+from eqt.ui.SessionDialogs import LoadSessionDialog
 
 from . import skip_ci
 

--- a/test/test_MainWindowWithSessionManagementDialogs.py
+++ b/test/test_MainWindowWithSessionManagementDialogs.py
@@ -1,14 +1,13 @@
 import unittest
 from unittest import mock
 
-from eqt.io import zip_directory
 from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 from eqt.ui.SessionDialogs import LoadSessionDialog
 
 from . import skip_ci
 
-''' Unit tests for the MainWindowWithSessionManagement class
-methods which create dialogs'''
+# Unit tests for the MainWindowWithSessionManagement class
+# methods which create dialogs
 
 
 @skip_ci

--- a/test/test_MainWindowWithSessionManagementDialogs.py
+++ b/test/test_MainWindowWithSessionManagementDialogs.py
@@ -1,16 +1,15 @@
-
 import unittest
 from unittest import mock
 
 from eqt.io import zip_directory
 from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
-
 from eqt.ui.SessionDialogs import LoadSessionDialog
 
 from . import skip_ci
 
 ''' Unit tests for the MainWindowWithSessionManagement class
 methods which create dialogs'''
+
 
 @skip_ci
 class TestMainWindowWithSessionManagementCreateLoadSessionDialog(unittest.TestCase):

--- a/test/test_MainWindowWithSessionManagementDialogs.py
+++ b/test/test_MainWindowWithSessionManagementDialogs.py
@@ -28,9 +28,6 @@ class TestMainWindowWithSessionManagementCreateLoadSessionDialog(unittest.TestCa
     def test_createLoadSessionDialog_populates_session_dropdown(self):
         dialog = self.smw.createLoadSessionDialog(self.zip_folders)
         assert dialog is not None
-        print(LoadSessionDialog)
-        print(type(LoadSessionDialog))
-        print(type(dialog))
         assert isinstance(dialog, LoadSessionDialog)
         select_session_combo = dialog.getWidget('select_session')
         assert select_session_combo is not None

--- a/test/test_MainWindowWithSessionManagementDialogs.py
+++ b/test/test_MainWindowWithSessionManagementDialogs.py
@@ -1,0 +1,68 @@
+
+import json
+import os
+import shutil
+import unittest
+from datetime import datetime
+from unittest import mock
+from unittest.mock import patch
+
+from PySide2.QtCore import QSettings, QThreadPool
+from PySide2.QtWidgets import QMenu, QMenuBar
+
+import eqt
+from eqt.io import zip_directory
+from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
+
+from eqt.ui.SessionDialogs import (LoadSessionDialog)
+
+from . import skip_ci
+
+''' Unit tests for the MainWindowWithSessionManagement class
+methods which create dialogs'''
+
+@skip_ci
+class TestMainWindowWithSessionManagementCreateLoadSessionDialog(unittest.TestCase):
+    '''
+    Tests the createLoadSessionDialog method of the MainWindowWithSessionManagement class
+
+    This method is responsible for creating the load session dialog
+    and populating it with the available sessions
+    '''
+    def setUp(self):
+        self.title = "title"
+        self.app_name = "app_name"
+        self.smw = MainWindowWithSessionManagement(self.title, self.app_name)
+        self.smw.sessions_directory = mock.MagicMock()
+        self.zip_folders = ["zip_folder_1", "zip_folder_2"]
+
+    def test_createLoadSessionDialog_populates_session_dropdown(self):
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+        assert dialog is not None
+        print(LoadSessionDialog)
+        print(type(LoadSessionDialog))
+        print(type(dialog))
+        assert isinstance(dialog, LoadSessionDialog)
+        select_session_combo = dialog.getWidget('select_session')
+        assert select_session_combo is not None
+        items_in_combo = [
+            select_session_combo.itemText(i) for i in range(select_session_combo.count())]
+        assert items_in_combo == self.zip_folders
+
+    def test_createLoadSessionDialog_connections(self):
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+
+        self.smw.loadSessionLoad = mock.MagicMock()
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector = mock.MagicMock()
+        self.smw.loadSessionNew = mock.MagicMock()
+
+        dialog = self.smw.createLoadSessionDialog(self.zip_folders)
+
+        dialog.Ok.click()
+        self.smw.loadSessionLoad.assert_called_once()
+
+        dialog.Select.click()
+        self.smw.selectLoadSessionsDirectorySelectedInSessionSelector.assert_called_with(dialog)
+
+        dialog.Cancel.click()
+        self.smw.loadSessionNew.assert_called_once()

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 from pathlib import Path
+from unittest import mock
 from unittest.mock import patch
 
 from PySide2.QtWidgets import QFileDialog
@@ -13,6 +14,8 @@ from eqt.ui.SessionDialogs import (
     SessionDirectorySelectionDialog,
     WarningDialog,
 )
+
+from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 
 from . import skip_ci
 
@@ -139,3 +142,4 @@ class TestAppSettingsDialog(unittest.TestCase):
     def test_init(self):
         asd = AppSettingsDialog()
         assert asd is not None
+

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from PySide2.QtWidgets import QFileDialog
 
+from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 from eqt.ui.SessionDialogs import (
     AppSettingsDialog,
     ErrorDialog,
@@ -14,8 +15,6 @@ from eqt.ui.SessionDialogs import (
     SessionDirectorySelectionDialog,
     WarningDialog,
 )
-
-from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 
 from . import skip_ci
 
@@ -142,4 +141,3 @@ class TestAppSettingsDialog(unittest.TestCase):
     def test_init(self):
         asd = AppSettingsDialog()
         assert asd is not None
-

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -1,12 +1,10 @@
 import os
 import unittest
 from pathlib import Path
-from unittest import mock
 from unittest.mock import patch
 
 from PySide2.QtWidgets import QFileDialog
 
-from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement
 from eqt.ui.SessionDialogs import (
     AppSettingsDialog,
     ErrorDialog,


### PR DESCRIPTION
Closes #78 

- I had to move the `TestMainWindowWithSessionManagementCreateLoadSessionDialog` test into a separate file: `test\test_MainWindowWithSessionManagementDialogs.py` because this needed to test elements of `LoadSessionDialog` whose import had been mocked elsewhere in the `test\test_MainWindowWithSessionManagement.py` file for other tests.
- In one test there was a dialog which was opened and blocked the other tests from running until we physically closed the dialog. I prevented this by using `dialog.open()` instead of `dialog._exec()`
- Fixed a failing unit test due to incorrect whitespace in a string.