### PR TITLE
Use QtPy abstraction layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Via `pip`/`conda`/`mamba`, i.e. any of the following:
 - `conda install -c conda-forge eqt`
 - `mamba install -c conda-forge eqt`
 
+Note that `eqt` use the [`qtpy`](https://github.com/spyder-ide/qtpy) abstraction layer for Qt bindings, so can work with either PySide or PyQt bindings. Therefore the package does not depend on either. If the environment does not already have a Qt binding then the user must install either `pyside2` or `pyqt5`.
+
 ## Examples
 
 See the [`examples`](examples) directory, e.g. how to launch a `QDialog` with a form inside using `eqt`'s [`QWidget`](examples/dialog_example.py) or [`FormDialog`](examples/dialog_example_2.py).

--- a/eqt/threading/QtThreading.py
+++ b/eqt/threading/QtThreading.py
@@ -7,8 +7,8 @@ import sys
 # https://www.geeksforgeeks.org/migrate-pyqt5-app-to-pyside2
 import traceback
 
-from PySide2 import QtCore
-from PySide2.QtCore import Slot
+from qtpy import QtCore
+from qtpy.QtCore import Slot
 
 
 class Worker(QtCore.QRunnable):

--- a/eqt/ui/FormDialog.py
+++ b/eqt/ui/FormDialog.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from . import UIFormFactory
 

--- a/eqt/ui/MainWindowWithProgressDialogs.py
+++ b/eqt/ui/MainWindowWithProgressDialogs.py
@@ -1,9 +1,9 @@
 import qdarkstyle
-from PySide2.QtCore import QSettings, QThreadPool
-from PySide2.QtGui import QKeySequence
-from PySide2.QtWidgets import QAction, QMainWindow
 from qdarkstyle.dark.palette import DarkPalette
 from qdarkstyle.light.palette import LightPalette
+from qtpy.QtCore import QSettings, QThreadPool
+from qtpy.QtGui import QKeySequence
+from qtpy.QtWidgets import QAction, QMainWindow
 
 from .ProgressTimerDialog import ProgressTimerDialog
 from .SessionDialogs import AppSettingsDialog

--- a/eqt/ui/MainWindowWithSessionManagement.py
+++ b/eqt/ui/MainWindowWithSessionManagement.py
@@ -4,8 +4,8 @@ import shutil
 from datetime import datetime
 from functools import partial
 
-from PySide2.QtGui import QCloseEvent, QKeySequence
-from PySide2.QtWidgets import QAction
+from qtpy.QtGui import QCloseEvent, QKeySequence
+from qtpy.QtWidgets import QAction
 
 from ..io import zip_directory
 from ..threading import Worker

--- a/eqt/ui/ProgressTimerDialog.py
+++ b/eqt/ui/ProgressTimerDialog.py
@@ -1,9 +1,9 @@
 import time
 from time import sleep
 
-from PySide2 import QtCore
-from PySide2.QtCore import Qt, QThreadPool
-from PySide2.QtWidgets import QProgressDialog
+from qtpy import QtCore
+from qtpy.QtCore import Qt, QThreadPool
+from qtpy.QtWidgets import QProgressDialog
 
 from ..threading import Worker
 

--- a/eqt/ui/ReOrderableListWidget.py
+++ b/eqt/ui/ReOrderableListWidget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 class ReOrderableListWidget(QtWidgets.QTableWidget):

--- a/eqt/ui/SessionDialogs.py
+++ b/eqt/ui/SessionDialogs.py
@@ -1,7 +1,7 @@
 import os
 
-from PySide2 import QtWidgets
-from PySide2.QtWidgets import (
+from qtpy import QtWidgets
+from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFileDialog,

--- a/eqt/ui/UIFormWidget.py
+++ b/eqt/ui/UIFormWidget.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from .UISliderWidget import UISliderWidget
 

--- a/eqt/ui/UIMultiStepWidget.py
+++ b/eqt/ui/UIMultiStepWidget.py
@@ -1,6 +1,6 @@
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QGroupBox, QHBoxLayout, QPushButton
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QPushButton
 
 
 class UIMultiStepWidget(object):

--- a/eqt/ui/UISliderWidget.py
+++ b/eqt/ui/UISliderWidget.py
@@ -1,5 +1,5 @@
-from PySide2 import QtCore
-from PySide2.QtWidgets import QSlider
+from qtpy import QtCore
+from qtpy.QtWidgets import QSlider
 
 
 class UISliderWidget(QSlider):

--- a/eqt/ui/UIStackedWidget.py
+++ b/eqt/ui/UIStackedWidget.py
@@ -1,6 +1,6 @@
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QHBoxLayout, QListWidget, QStackedWidget, QVBoxLayout, QWidget
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QHBoxLayout, QListWidget, QStackedWidget, QVBoxLayout, QWidget
 
 from .UIFormWidget import UIFormFactory
 

--- a/examples/MainWindowWithSessionManagement_example.py
+++ b/examples/MainWindowWithSessionManagement_example.py
@@ -1,7 +1,7 @@
 import sys
 
-from PySide2 import QtWidgets
-from PySide2.QtWidgets import QApplication
+from qtpy import QtWidgets
+from qtpy.QtWidgets import QApplication
 
 from eqt import __version__
 from eqt.ui.MainWindowWithSessionManagement import MainWindowWithSessionManagement

--- a/examples/advanced_dialog_example.py
+++ b/examples/advanced_dialog_example.py
@@ -1,7 +1,7 @@
 import sys
 
 import utilitiesForExamples
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui.FormDialog import AdvancedFormDialog
 from eqt.ui.UIFormWidget import FormWidget

--- a/examples/dialog_example.py
+++ b/examples/dialog_example.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import UIFormFactory
 

--- a/examples/dialog_example_2.py
+++ b/examples/dialog_example_2.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog
 

--- a/examples/dialog_example_3_save_default.py
+++ b/examples/dialog_example_3_save_default.py
@@ -1,7 +1,7 @@
 import sys
 
 import utilitiesForExamples as utex
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog
 

--- a/examples/dialog_multistep_example.py
+++ b/examples/dialog_multistep_example.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import UIFormFactory, UIMultiStepFactory
 

--- a/examples/dialog_save_state_example.py
+++ b/examples/dialog_save_state_example.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog
 from eqt.ui.UISliderWidget import UISliderWidget

--- a/examples/insert_widgets_example.py
+++ b/examples/insert_widgets_example.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog, UIFormWidget
 

--- a/examples/progress_timer_dialog_example.py
+++ b/examples/progress_timer_dialog_example.py
@@ -1,8 +1,8 @@
 import sys
 from time import sleep
 
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtCore import QThreadPool
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import QThreadPool
 
 from eqt.threading import Worker
 from eqt.ui import ProgressTimerDialog

--- a/examples/remove_widgets_example.py
+++ b/examples/remove_widgets_example.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog, UIFormWidget
 

--- a/examples/reorderable_list_widget_example.py
+++ b/examples/reorderable_list_widget_example.py
@@ -1,8 +1,8 @@
 import sys
 
 import qdarkstyle
-from PySide2 import QtWidgets
 from qdarkstyle.dark.palette import DarkPalette
+from qtpy import QtWidgets
 
 from eqt.ui.ReOrderableListWidget import ReOrderableListWidget
 

--- a/examples/utilitiesForExamples.py
+++ b/examples/utilitiesForExamples.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 from eqt.ui.UISliderWidget import UISliderWidget
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only"]
-dependencies = ["pyside2", "qdarkstyle"]
+dependencies = ["qtpy", "qdarkstyle"]
 
 [project.optional-dependencies]
 dev = ["pytest>=6", "pytest-cov", "pytest-timeout"]

--- a/scripts/eqt_env.yml
+++ b/scripts/eqt_env.yml
@@ -5,5 +5,5 @@ channels:
 dependencies:
   - python
   - pip
-  - pyside2
+  - qtpy
   - qdarkstyle

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 import os
 
-from PySide2 import QtWidgets
 from pytest import skip
+from qtpy import QtWidgets
 
 from eqt.ui import FormDialog
 

--- a/test/dialog_example_2_test.py
+++ b/test/dialog_example_2_test.py
@@ -1,9 +1,9 @@
 import sys
 import unittest
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
-from PySide2.QtTest import QTest
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
 
 from eqt.ui import FormDialog
 

--- a/test/test_MainWindowWithSessionManagement.py
+++ b/test/test_MainWindowWithSessionManagement.py
@@ -6,8 +6,8 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import patch
 
-from PySide2.QtCore import QSettings, QThreadPool
-from PySide2.QtWidgets import QMenu, QMenuBar
+from qtpy.QtCore import QSettings, QThreadPool
+from qtpy.QtWidgets import QMenu, QMenuBar
 
 import eqt
 from eqt.io import zip_directory

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -83,19 +83,17 @@ class TestSessionDirectorySelectionDialog(unittest.TestCase):
             sdsd.getWidget("select_session_directory").text(),
             "Select a session directory to save and retrieve all Test App Sessions:")
 
-    @patch("PySide2.QtWidgets.QFileDialog.getExistingDirectory")
+    @patch("qtpy.QtWidgets.QFileDialog.getExistingDirectory")
     def test_browse_for_dir_button_makes_file_dialog_for_getting_dir(self, mock_dialog_call):
         sdsd = SessionDirectorySelectionDialog()
         sdsd.browse_for_dir()
         mock_dialog_call.assert_called_once()
 
-    @patch("PySide2.QtWidgets.QFileDialog.getExistingDirectory")
-    def test_browse_button_calls_browse_for_dir(self, mock_dialog_call):
+    @patch.object(SessionDirectorySelectionDialog, "browse_for_dir")
+    def test_browse_button_calls_browse_for_dir(self, mock_browse):
         sdsd = SessionDirectorySelectionDialog()
-        sdsd.browse_for_dir = unittest.mock.Mock()
-        QFileDialog.getExistingDirectory = unittest.mock.Mock()
         sdsd.getWidget("selected_dir").click()
-        sdsd.browse_for_dir.assert_called_once()
+        mock_browse.assert_called_once()
 
     def test_browse_dialog_updates_session_directory_label(self):
         example_dir = "C:\\Users\\test_user\\Documents\\test_dir"

--- a/test/test_SessionDialogs.py
+++ b/test/test_SessionDialogs.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from PySide2.QtWidgets import QFileDialog
+from qtpy.QtWidgets import QFileDialog
 
 from eqt.ui.SessionDialogs import (
     AppSettingsDialog,

--- a/test/test__formUI_status_test.py
+++ b/test/test__formUI_status_test.py
@@ -2,9 +2,9 @@ import abc
 import unittest
 from unittest import mock
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import Qt
-from PySide2.QtTest import QTest
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtTest import QTest
 
 from eqt.ui.FormDialog import AdvancedFormDialog, FormDialog
 from eqt.ui.UIFormWidget import FormDockWidget, FormWidget


### PR DESCRIPTION
Closes #2

This switches to importing Qt classes via the qtpy abstraction layer. The library will then use which ever Qt binding you have in your environment. If you have multiple, its possible to select one using an environment variable (see https://github.com/spyder-ide/qtpy).

A small change to some mocking in a test was needed.

This passes all the tests, but has not been tested for an application that uses the library.

An application that uses eqt, will now need to add a dependency on the Qt binding that it wants to use.