### PR TITLE
Fix SessionDirectorySelectionDialog Disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version x.x.x
+- Change SessionDirectorySelectionDialog `.open()` call to `.exec()` (#162)
+
 # Version 1.0.1
 - Add NoBorderScrollArea, example and tests (#155)
 - Edit next and prev in UIMultiStepWidget (#151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version x.x.x
-- Change SessionDirectorySelectionDialog `.open()` call to `.exec()` (#162)
+- Change SessionDirectorySelectionDialog `.open()` call to `.exec()` (#163)
 
 # Version 1.0.1
 - Add NoBorderScrollArea, example and tests (#155)

--- a/eqt/ui/MainWindowWithSessionManagement.py
+++ b/eqt/ui/MainWindowWithSessionManagement.py
@@ -252,7 +252,7 @@ class MainWindowWithSessionManagement(MainWindowWithProgressDialogs):
             session_folder_selection_dialog.selected_dir = os.path.split(
                 self.sessions_directory)[0]
 
-        session_folder_selection_dialog.open()
+        session_folder_selection_dialog.exec()
 
         return session_folder_selection_dialog
 


### PR DESCRIPTION
Closes [#162](https://github.com/TomographicImaging/eqt/issues/162)

Relates to CIL-GUI issue [#286](https://github.com/TomographicImaging/CIL-GUI/issues/286) and pull request [#287](https://github.com/TomographicImaging/CIL-GUI/pull/287)

After starting CIL-GUI using the `epac_ct` command, the splash screen appears. Shortly afterwards, the SessionDirectorySelectionDialog appears briefly before closing, the program then exits with Exit Code 1. 

Changing the `.open()` call to `.exec()` allows the dialog to persist without automatically closing. 