### PR TITLE
Fix unit tests by mocking the creation of `createSessionsDirectorySelectionDialog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Rename `/scripts` directory to `/recipe` (#161)
 - Update `CONTRIBUTING.md` with detailed installation and contribution instructions (#161)
 - Limit Python version to <3.12 in conda recipe (#161)
-- Change SessionDirectorySelectionDialog `.open()` call to `.exec()` (#163)
+- Change SessionDirectorySelectionDialog `.open()` call to `.exec()` (#163, #165)
 
 # Version 1.0.1
 - Add NoBorderScrollArea, example and tests (#155)

--- a/eqt/ui/MainWindowWithSessionManagement.py
+++ b/eqt/ui/MainWindowWithSessionManagement.py
@@ -337,7 +337,8 @@ class MainWindowWithSessionManagement(MainWindowWithProgressDialogs):
         date_time = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
         session_folder_name = f'{self.app_name}-{date_time}'
         session_folder_path = os.path.join(self.sessions_directory, session_folder_name)
-        os.mkdir(session_folder_path)
+        if not os.path.isdir(session_folder_path):
+            os.mkdir(session_folder_path)
         self.current_session_folder = os.path.abspath(session_folder_path)
 
     def loadSessionConfig(self, folder, **kwargs):

--- a/test/test_MainWindowWithSessionManagement.py
+++ b/test/test_MainWindowWithSessionManagement.py
@@ -25,6 +25,7 @@ class TestMainWindowWithSessionManagementInit(unittest.TestCase):
         # Testing the init method, so don't call init in the setUp
         self.title = "title"
         self.app_name = "App Name"
+        MainWindowWithSessionManagement.createSessionsDirectorySelectionDialog = mock.MagicMock()
 
     def test_init_sets_title_and_app_name(self):
         smw = MainWindowWithSessionManagement(self.title, self.app_name)
@@ -191,7 +192,8 @@ class TestMainWindowWithSessionManagementCreateSessionSelector(unittest.TestCase
         self.title = "title"
         self.app_name = "app_name"
         self.smw = MainWindowWithSessionManagement(self.title, self.app_name)
-        os.mkdir("Test Folder")
+        if not os.path.isdir("Test Folder"):
+            os.mkdir("Test Folder")
         os.chdir("Test Folder")
         os.mkdir("Session Folder")
         self.smw.sessions_directory = "."

--- a/test/test_MainWindowWithSessionManagement.py
+++ b/test/test_MainWindowWithSessionManagement.py
@@ -192,9 +192,9 @@ class TestMainWindowWithSessionManagementCreateSessionSelector(unittest.TestCase
         self.title = "title"
         self.app_name = "app_name"
         self.smw = MainWindowWithSessionManagement(self.title, self.app_name)
-        if not os.path.isdir("Test Folder"):
-            os.mkdir("Test Folder")
-        os.chdir("Test Folder")
+        if not os.path.isdir("Test_Folder"):
+            os.mkdir("Test_Folder")
+        os.chdir("Test_Folder")
         os.mkdir("Session Folder")
         self.smw.sessions_directory = "."
 
@@ -227,7 +227,7 @@ class TestMainWindowWithSessionManagementCreateSessionSelector(unittest.TestCase
 
     def tearDown(self):
         os.chdir("..")
-        shutil.rmtree("Test Folder")
+        shutil.rmtree("Test_Folder")
 
 
 @skip_ci
@@ -266,8 +266,8 @@ class TestCreateSessionFolder(unittest.TestCase):
 
         self.smw = MainWindowWithSessionManagement(self.title, self.app_name)
 
-        os.mkdir("Test Folder")
-        os.chdir("Test Folder")
+        os.mkdir("Test_Folder")
+        os.chdir("Test_Folder")
         self.date_time = datetime.now().strftime("%d-%m-%Y-%H-%M-%S")
 
     def test_createSessionFolder(self):
@@ -280,7 +280,7 @@ class TestCreateSessionFolder(unittest.TestCase):
 
     def tearDown(self):
         os.chdir("..")
-        shutil.rmtree("Test Folder")
+        shutil.rmtree("Test_Folder")
 
 
 @skip_ci
@@ -294,8 +294,8 @@ class TestLoadSessionConfig(unittest.TestCase):
     def setUp(self):
         '''
         Create a session zip file, which contains a session.json file'''
-        os.mkdir("Test Folder")
-        os.chdir("Test Folder")
+        os.mkdir("Test_Folder")
+        os.chdir("Test_Folder")
 
         self.title = "title"
         self.app_name = "app_name"
@@ -324,10 +324,10 @@ class TestLoadSessionConfig(unittest.TestCase):
     def tearDown(self):
         os.chdir("..")
         try:
-            shutil.rmtree("Test Folder")
+            shutil.rmtree("Test_Folder")
         except Exception:
             os.chdir("..")
-            shutil.rmtree("Test Folder")
+            shutil.rmtree("Test_Folder")
 
 
 @skip_ci
@@ -356,13 +356,13 @@ class TestSaveSession(unittest.TestCase):
         mock_zip_directory.assert_called_once_with(self.smw.current_session_folder, False)
 
     def test_moveSessionFolder(self):
-        os.mkdir("Test Folder")
+        os.mkdir("Test_Folder")
         new_folder_to_save_to = os.path.join(
-            "Test Folder", self.session_name + "_" + datetime.now().strftime("%d-%m-%Y-%H-%M"))
+            "Test_Folder", self.session_name + "_" + datetime.now().strftime("%d-%m-%Y-%H-%M"))
 
         # Make the current session folder, with a test file inside it:
 
-        self.smw.sessions_directory = os.path.abspath("Test Folder")
+        self.smw.sessions_directory = os.path.abspath("Test_Folder")
         current_session_folder = os.path.join(self.smw.sessions_directory,
                                               "Current Session Folder")
         os.mkdir(current_session_folder)
@@ -386,7 +386,7 @@ class TestSaveSession(unittest.TestCase):
             raise e
 
         finally:
-            shutil.rmtree("Test Folder")
+            shutil.rmtree("Test_Folder")
 
     def test_saveSessionConfigToJson(self):
 
@@ -403,8 +403,8 @@ class TestSaveSession(unittest.TestCase):
 
         self.smw.getSessionConfig = mock.MagicMock(return_value=config)
 
-        os.mkdir("Test Folder")
-        os.chdir("Test Folder")
+        os.mkdir("Test_Folder")
+        os.chdir("Test_Folder")
         self.smw.current_session_folder = "."
         try:
             self.smw.saveSessionConfigToJson()
@@ -416,7 +416,7 @@ class TestSaveSession(unittest.TestCase):
             raise e
         finally:
             os.chdir("..")
-            shutil.rmtree("Test Folder")
+            shutil.rmtree("Test_Folder")
 
 
 @skip_ci


### PR DESCRIPTION
Closes #164 